### PR TITLE
Specifying minimum version of Java

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,5 +12,7 @@
     </modules>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
     </properties>
 </project>


### PR DESCRIPTION
This project is incompatible with versions lower than 8...
see: https://github.com/AdamBien/perceptor/blob/master/perceptor/src/main/java/com/airhacks/interceptor/monitoring/control/InvocationMonitoring.java

use Stream!